### PR TITLE
changed color of highlighted "quick action"

### DIFF
--- a/themes/materia.json
+++ b/themes/materia.json
@@ -132,6 +132,7 @@
         "scrollbarSlider.activeBackground": "#424242",
         "scrollbarSlider.hoverBackground": "#424242",
         "editor.selectionBackground": "#424242",
+        "menu.selectionBackground": "#424242",
 
         "editorSuggestWidget.selectedBackground": "#363636",
         "list.activeSelectionBackground": "#363636",


### PR DESCRIPTION
Related to #6, I tried to use a more legible color for highlighted "menu item"

Here it what it looks like : 
![image](https://user-images.githubusercontent.com/6715182/47357562-476d9500-d6c7-11e8-82a3-2e4a9b9023b6.png)
